### PR TITLE
epoxy 1.5.10

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,11 +13,6 @@ if [[ $target_platform == osx* ]] ; then
     meson_config_args+=(
         -D x11=false
     )
-elif [[ $target_platform == linux-ppc64le ]] || [[ $target_platform == linux-s390x ]]; then
-    meson_config_args+=(
-        -D egl=no
-        -D x11=true
-    )
 else
     meson_config_args+=(
         -D egl=yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,43 +2,64 @@
 # This file is licensed under a 3-clause BSD license; see LICENSE.txt.
 
 {% set name = "epoxy" %}
-{% set version = "1.5.4" %}
-{% set sha256 = "0bd2cc681dfeffdef739cb29913f8c3caa47a88a451fd2bc6e606c02997289d2" %}
+{% set version = "1.5.10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/anholt/libepoxy/releases/download/{{ version }}/libepoxy-{{ version }}.tar.xz
-  sha256: {{ sha256 }}
+  url: https://github.com/anholt/libepoxy/archive/refs/tags/{{ version }}.tar.gz
+  sha256: a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15
 
 build:
-  number: 2
-  skip: true  # [win and vc<14]
+  number: 0
   run_exports:
     - {{ pin_subpackage('epoxy', max_pin='x.x') }}
 
 requirements:
   build:
     - meson
-    - ninja
+    - ninja-base
     - pkg-config
     - pthread-stubs  # [linux]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - {{ cdt('mesa-libEGL-devel') }}  # [linux and not ppc64le]
-    - {{ cdt('mesa-libGL-devel') }}  # [linux and not s390x]
-    - {{ cdt('libx11-devel') }}  # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - {{ cdt('xorg-x11-util-macros') }}  # [linux and not aarch64]
+  host:
+    - libdrm                    # [linux]
+    - libegl-devel              # [linux]
+    - libgl-devel               # [linux]
+    - libglx-devel              # [linux]
+    - xorg-libx11               # [linux]
+    - xorg-libxdamage           # [linux]
+    - xorg-libxext              # [linux]
+    - xorg-libxfixes            # [linux]
+    - xorg-libxxf86vm           # [linux]
 
 test:
+  requires:
+    - pkg-config
+    - libegl-devel  # [linux]
+    - libgl-devel   # [linux]
+    - libglx-devel  # [linux]
   commands:
-    - test -f $PREFIX/include/epoxy/common.h  # [unix]
-    - test -f $PREFIX/lib/libepoxy${SHLIB_EXT}  # [unix]
-    - if not exist %PREFIX%\\Library\\include\\epoxy\\common.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\bin\\epoxy-0.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\epoxy.lib exit 1  # [win]
+    - test -f $PREFIX/include/epoxy/common.h         # [unix]
+    - test -f $PREFIX/include/epoxy/egl.h            # [linux]
+    - test -f $PREFIX/include/epoxy/egl_generated.h  # [linux]
+    - test -f $PREFIX/include/epoxy/gl.h             # [unix]
+    - test -f $PREFIX/include/epoxy/gl_generated.h   # [unix]
+    - test -f $PREFIX/include/epoxy/glx.h            # [linux]
+    - test -f $PREFIX/include/epoxy/glx_generated.h  # [linux]
+    - test -f $PREFIX/lib/libepoxy${SHLIB_EXT}       # [unix]
+    - if not exist %PREFIX%\\Library\\include\\epoxy\\common.h exit 1         # [win]
+    - if not exist %PREFIX%\\Library\\include\\epoxy\\gl.h exit 1             # [win]
+    - if not exist %PREFIX%\\Library\\include\\epoxy\\gl_generated.h exit 1   # [win]
+    - if not exist %PREFIX%\\Library\\include\\epoxy\\wgl.h exit 1            # [win]
+    - if not exist %PREFIX%\\Library\\include\\epoxy\\wgl_generated.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\epoxy-0.dll exit 1                 # [win]
+    - if not exist %PREFIX%\\Library\\lib\\epoxy.lib exit 1                   # [win]
+    - pkg-config --debug --exists epoxy
+    - pkg-config --validate epoxy
 
 about:
   home: https://github.com/anholt/libepoxy


### PR DESCRIPTION
epoxy 1.5.10

**Destination channel:** {defaults}

### Links

- jira | https://anaconda.atlassian.net/browse/PKG-11101
- dev_url (recipe) | https://github.com/anholt/libepoxy/tree/1.5.10
- conda-forge | https://github.com/conda-forge/epoxy-feedstock
- Anaconda Recipes | https://github.com/AnacondaRecipes/epoxy-feedstock



### Explanation of changes:

- version bump 1.5.4 → 1.5.10
- build number reset 2 → 0
- build.sh simplified by removing special ppc64le/s390x meson EGL/X11 handling
- build deps switched ninja → ninja-base
- linux host deps updated to libdrm, libegl-devel, libgl-devel, libglx-devel, xorg libs
- tests expanded to check epoxy headers (egl/gl/glx/wgl) and pkg-config validation
- add win build
